### PR TITLE
Implement emitter fiscal regime support

### DIFF
--- a/l10n_mx_edi_fiscal_regime/__manifest__.py
+++ b/l10n_mx_edi_fiscal_regime/__manifest__.py
@@ -26,6 +26,7 @@
         "data/l10n_mx_edi_fiscal_regime_data.xml",
         "views/l10n_mx_edi_fiscal_regime_views.xml",
         "views/res_partner_views.xml",
+        "views/account_journal_views.xml",
         "views/account_move_views.xml",
     ],
     "post_init_hook": "post_init_hook",

--- a/l10n_mx_edi_fiscal_regime/models/__init__.py
+++ b/l10n_mx_edi_fiscal_regime/models/__init__.py
@@ -1,3 +1,4 @@
 from . import l10n_mx_edi_fiscal_regime
 from . import res_partner
 from . import account_move
+from . import account_journal

--- a/l10n_mx_edi_fiscal_regime/models/account_journal.py
+++ b/l10n_mx_edi_fiscal_regime/models/account_journal.py
@@ -1,0 +1,28 @@
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    default_emitter_fiscal_regime = fields.Many2one(
+        "l10n_mx_edi.fiscal.regime",
+        string="Default Emitter Fiscal Regime",
+        domain="[('id', 'in', company_id.partner_id.allowed_fiscal_regimes.ids)]",
+        help="Fiscal regime used as default for CFDI emission on this journal",
+    )
+
+    @api.constrains("default_emitter_fiscal_regime")
+    def _check_default_emitter_fiscal_regime(self):
+        for journal in self:
+            if (
+                journal.default_emitter_fiscal_regime
+                and journal.default_emitter_fiscal_regime
+                not in journal.company_id.partner_id.allowed_fiscal_regimes
+            ):
+                raise ValidationError(
+                    self.env._(
+                        "The default emitter fiscal regime must be one of the allowed fiscal regimes for the company."
+                    )
+                )
+

--- a/l10n_mx_edi_fiscal_regime/models/account_move.py
+++ b/l10n_mx_edi_fiscal_regime/models/account_move.py
@@ -4,6 +4,16 @@ from odoo import api, fields, models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
+    emitter_fiscal_regime = fields.Many2one(
+        "l10n_mx_edi.fiscal.regime",
+        string="Emitter Fiscal Regime",
+        domain="[('id', 'in', company_id.partner_id.allowed_fiscal_regimes.ids)]",
+        compute="_compute_emitter_fiscal_regime",
+        store=True,
+        readonly=True,
+        required=True,
+    )
+
     l10n_mx_edi_fiscal_regime_id = fields.Many2one(
         "l10n_mx_edi.fiscal.regime",
         string="Fiscal Regime",
@@ -17,6 +27,11 @@ class AccountMove(models.Model):
     l10n_mx_edi_fiscal_regime_ids = fields.Many2many(
         "l10n_mx_edi.fiscal.regime", compute="_compute_l10n_mx_edi_fiscal_regime_ids"
     )
+
+    @api.depends("journal_id")
+    def _compute_emitter_fiscal_regime(self):
+        for move in self:
+            move.emitter_fiscal_regime = move.journal_id.default_emitter_fiscal_regime
 
     @api.depends("partner_id", "partner_id.l10n_mx_edi_fiscal_regime_ids")
     def _compute_l10n_mx_edi_fiscal_regime_ids(self):
@@ -48,6 +63,11 @@ class AccountMove(models.Model):
         self.l10n_mx_edi_fiscal_regime_id = l10n_mx_edi_fiscal_regime_id
         return res
 
+    @api.onchange("journal_id")
+    def _onchange_journal_id_emitter(self):
+        if self.journal_id:
+            self.emitter_fiscal_regime = self.journal_id.default_emitter_fiscal_regime
+
     def _l10n_mx_edi_get_customer_fiscal_regime(self):
         """Helper method to return the selected fiscal regime for CFDI generation.
         This method should be called by the EDI process to get the fiscal regime.
@@ -63,6 +83,17 @@ class AccountMove(models.Model):
             return invoice_customer.l10n_mx_edi_fiscal_regime or "616"
         return False
 
+    def _l10n_mx_edi_get_emitter_fiscal_regime(self):
+        self.ensure_one()
+        if self.emitter_fiscal_regime:
+            return self.emitter_fiscal_regime.code
+        if self.journal_id.default_emitter_fiscal_regime:
+            return self.journal_id.default_emitter_fiscal_regime.code
+        company_partner = self.company_id.partner_id
+        if company_partner.l10n_mx_edi_fiscal_regime_id:
+            return company_partner.l10n_mx_edi_fiscal_regime_id.code
+        return company_partner.l10n_mx_edi_fiscal_regime
+
     def _l10n_mx_edi_add_invoice_cfdi_values(self, cfdi_values):
         """Include the selected fiscal regime in CFDI values."""
         res = super()._l10n_mx_edi_add_invoice_cfdi_values(cfdi_values)
@@ -73,4 +104,10 @@ class AccountMove(models.Model):
         if customer_fiscal_regime_code and customer_values.get("regimen_fiscal_receptor"):
             customer_values["regimen_fiscal_receptor"] = customer_fiscal_regime_code
         cfdi_values.update({"receptor": customer_values})
+
+        emitter_values = cfdi_values.get("emisor", {})
+        emitter_code = self._l10n_mx_edi_get_emitter_fiscal_regime()
+        if emitter_code and emitter_values.get("regimen_fiscal"):
+            emitter_values["regimen_fiscal"] = emitter_code
+        cfdi_values.update({"emisor": emitter_values})
         return res

--- a/l10n_mx_edi_fiscal_regime/models/res_partner.py
+++ b/l10n_mx_edi_fiscal_regime/models/res_partner.py
@@ -15,6 +15,15 @@ class ResPartner(models.Model):
         string="Allowed Fiscal Regimes",
         help="Fiscal regimes that this partner can use for invoicing",
     )
+
+    allowed_fiscal_regimes = fields.Many2many(
+        "l10n_mx_edi.fiscal.regime",
+        "partner_allowed_fiscal_regime_rel",
+        "partner_id",
+        "fiscal_regime_id",
+        string="Allowed Emitter Fiscal Regimes",
+        help="Fiscal regimes that this company can use as issuer",
+    )
     l10n_mx_edi_fiscal_regime_id = fields.Many2one(
         "l10n_mx_edi.fiscal.regime",
         string="Fiscal Regime",

--- a/l10n_mx_edi_fiscal_regime/views/account_journal_views.xml
+++ b/l10n_mx_edi_fiscal_regime/views/account_journal_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_account_journal_form_emitter_regime" model="ir.ui.view">
+        <field name="name">account.journal.form.emitter.regime</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='l10n_latam_identification_type_id']" position="after">
+                <field name="default_emitter_fiscal_regime" options="{'no_create': True, 'no_open': True}" invisible="type != 'sale'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>
+

--- a/l10n_mx_edi_fiscal_regime/views/res_partner_views.xml
+++ b/l10n_mx_edi_fiscal_regime/views/res_partner_views.xml
@@ -19,6 +19,13 @@
                     options="{'no_create': True, 'no_open': True}"
                 />
                 <field
+                    name="allowed_fiscal_regimes"
+                    widget="many2many_tags"
+                    placeholder="Select emitter fiscal regimes..."
+                    options="{'no_create': True, 'no_open': True}"
+                    groups="base.group_system"
+                />
+                <field
                     name="l10n_mx_edi_fiscal_regime_id"
                     placeholder="Select default fiscal regime..."
                     options="{'no_create': True, 'no_open': True}"


### PR DESCRIPTION
## Summary
- add allowed emitter fiscal regimes for company partners
- allow setting a default emitter regime on sales journals
- automatically assign the emitter regime to invoices and export it to CFDI

## Testing
- `pytest -k nothing -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_b_6846fa33f0e8832c802b413431f5aee6

## Resumen por Sourcery

Implementa soporte para los regímenes fiscales del emisor permitiendo a los socios definir los regímenes permitidos, a los diarios establecer un régimen por defecto y a las facturas heredar e incluir automáticamente el régimen del emisor en las exportaciones CFDI.

Nuevas Funcionalidades:
- Permite a los socios configurar los regímenes fiscales del emisor permitidos a través de un campo Many2many.
- Añade un campo de régimen fiscal del emisor por defecto en los diarios de venta con validación contra los regímenes permitidos del socio.
- Calcula, almacena y exporta el régimen fiscal del emisor en los movimientos contables en los valores CFDI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement support for emitter fiscal regimes by enabling partners to define allowed regimes, journals to set a default regime, and invoices to automatically inherit and include the emitter regime in CFDI exports.

New Features:
- Allow partners to configure allowed emitter fiscal regimes via a Many2many field.
- Add a default emitter fiscal regime field on sales journals with validation against the partner’s allowed regimes.
- Compute, store, and export the emitter fiscal regime on account moves in the CFDI values.

</details>