### PR TITLE
Add workflow button on bank statement line

### DIFF
--- a/marin/models/account_bank_statement_line.py
+++ b/marin/models/account_bank_statement_line.py
@@ -2,7 +2,7 @@ import re
 from itertools import product
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.addons.base.models.res_bank import sanitize_account_number
 
 
@@ -124,3 +124,17 @@ class AccountBankStatementLine(models.Model):
                 return partner
 
         return self.env["res.partner"]
+
+    def action_execute_workflow(self):
+        """Execute a custom workflow for this bank statement line."""
+        self.ensure_one()
+        # Placeholder for workflow logic
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": _("Workflow"),
+                "message": _("Workflow executed successfully."),
+                "type": "success",
+            },
+        }

--- a/marin/views/account_bank_statement_views.xml
+++ b/marin/views/account_bank_statement_views.xml
@@ -10,4 +10,16 @@
             </xpath>
         </field>
     </record>
+
+    <record id="view_bank_statement_line_form_workflow" model="ir.ui.view">
+        <field name="name">account.bank.statement.line.form.workflow</field>
+        <field name="model">account.bank.statement.line</field>
+        <field name="inherit_id" ref="account.view_bank_statement_line_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button name="action_execute_workflow" string="Execute Workflow"
+                        type="object" class="btn-primary"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
## Summary
- extend bank statement line model to add an action that shows a notification
- include new button in bank statement line form view to trigger the workflow

## Testing
- `python -m py_compile marin/models/account_bank_statement_line.py`

------
https://chatgpt.com/codex/tasks/task_b_684c77331fd0832ca52104e9631d94d1

## Resumen por Sourcery

Se introduce una acción de Ejecutar Flujo de Trabajo en las líneas de extracto bancario y se añade un botón de vista de formulario para activarla con una notificación de éxito.

Nuevas Funcionalidades:
- Se añade el método `action_execute_workflow` a `account.bank.statement.line` para lanzar un flujo de trabajo de notificación al cliente.
- Se inyecta un botón "Ejecutar Flujo de Trabajo" en el formulario de línea de extracto bancario para invocar la acción del flujo de trabajo.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an Execute Workflow action on bank statement lines and add a form-view button to trigger it with a success notification.

New Features:
- Add action_execute_workflow method to account.bank.statement.line to launch a client notification workflow
- Inject an “Execute Workflow” button into the bank statement line form to invoke the workflow action

</details>