### PR TITLE
Implement template product onchange and st_line linking

### DIFF
--- a/account_move_operation/models/account_move_operation.py
+++ b/account_move_operation/models/account_move_operation.py
@@ -186,6 +186,7 @@ class AccountMoveOperation(models.Model):
             "state": "waiting",
             "template_id": rule.template_id.id,
             "operation_id": self.id,
+            "st_line_id": self.st_line_id.id,
             "date_last_document": rule.date_last_document,
             "diff_partner": rule.diff_partner,
             "action_id": rule.id,

--- a/account_move_template/models/account_move_template_line.py
+++ b/account_move_template/models/account_move_template_line.py
@@ -76,6 +76,11 @@ class AccountMoveTemplateLine(models.Model):
         string="Unit Price",
         digits="Product Price",
     )
+    tax_ids = fields.Many2many(
+        comodel_name="account.tax",
+        string="Taxes",
+        check_company=True,
+    )
     discount = fields.Float(
         string="Discount (%)",
         digits="Discount",
@@ -108,6 +113,14 @@ class AccountMoveTemplateLine(models.Model):
                 line.product_uom_id = line.product_id.uom_id
             else:
                 line.product_uom_id = False
+
+    @api.onchange("product_id")
+    def _onchange_product_id_set_values(self):
+        for line in self:
+            if not line.product_id:
+                continue
+            line.price_unit = line.product_id.list_price
+            line.tax_ids = line.product_id.taxes_id
 
     # @api.onchange("product_id")
     # def _onchange_product_id(self):

--- a/account_move_template/models/account_move_template_line.py
+++ b/account_move_template/models/account_move_template_line.py
@@ -120,7 +120,7 @@ class AccountMoveTemplateLine(models.Model):
             if not line.product_id:
                 continue
             line.price_unit = line.product_id.list_price
-            line.tax_ids = line.product_id.taxes_id
+            line.tax_ids = line.product_id.suppliers_taxes_id
 
     # @api.onchange("product_id")
     # def _onchange_product_id(self):

--- a/account_move_template/views/account_move_template_views.xml
+++ b/account_move_template/views/account_move_template_views.xml
@@ -105,6 +105,8 @@
                                         column_invisible="parent.move_type == 'entry'" />
                                     <field name="price_unit" string="Price"
                                         column_invisible="parent.move_type == 'entry'" />
+                                    <field name="tax_ids" widget="many2many_tags"
+                                        column_invisible="parent.move_type == 'entry'"/>
                                     <field name="discount" width="50px" string="Disc.%"
                                         optional="hide"
                                         column_invisible="parent.move_type == 'entry'" />

--- a/account_move_template/wizard/account_move_template_line_run.py
+++ b/account_move_template/wizard/account_move_template_line_run.py
@@ -52,6 +52,10 @@ class AccountMoveTemplateLineRun(models.TransientModel):
         string="Unit Price",
         digits="Product Price",
     )
+    tax_ids = fields.Many2many(
+        comodel_name="account.tax",
+        string="Taxes",
+    )
     discount = fields.Float(
         string="Discount (%)",
         digits="Discount",
@@ -62,3 +66,12 @@ class AccountMoveTemplateLineRun(models.TransientModel):
     )
     python_code = fields.Text(string="Formula", readonly=True)
     note = fields.Char()
+
+    @api.onchange("product_id")
+    def _onchange_product_id_set_values(self):
+        for line in self:
+            if not line.product_id:
+                continue
+            line.price_unit = line.product_id.list_price
+            line.tax_ids = line.product_id.taxes_id
+            line.product_uom_id = line.product_id.uom_id

--- a/account_move_template/wizard/account_move_template_line_run.py
+++ b/account_move_template/wizard/account_move_template_line_run.py
@@ -73,5 +73,5 @@ class AccountMoveTemplateLineRun(models.TransientModel):
             if not line.product_id:
                 continue
             line.price_unit = line.product_id.list_price
-            line.tax_ids = line.product_id.taxes_id
+            line.tax_ids = line.product_id.suppliers_taxes_id
             line.product_uom_id = line.product_id.uom_id

--- a/account_move_template/wizard/account_move_template_run.py
+++ b/account_move_template/wizard/account_move_template_run.py
@@ -165,6 +165,7 @@ class AccountMoveTemplateRun(models.TransientModel):
             vals["quantity"] = self.quantity or line.quantity
             vals["price_unit"] = self.price_unit or line.price_unit or 0.0
             vals["discount"] = self.discount or line.discount
+            vals["tax_ids"] = [(6, 0, line.tax_ids.ids)]
 
         return vals
 
@@ -220,6 +221,7 @@ class AccountMoveTemplateRun(models.TransientModel):
             "product_uom_id": tmpl_line.product_uom_id.id or False,
             "quantity": quantity,
             "price_unit": price_unit,
+            "tax_ids": [(6, 0, tmpl_line.tax_ids.ids)],
             "discount": tmpl_line.discount or False,
             "balance": tmpl_line.balance or False,
             "python_code": (

--- a/account_move_template/wizard/account_move_template_run_views.xml
+++ b/account_move_template/wizard/account_move_template_run_views.xml
@@ -42,6 +42,8 @@
                                 column_invisible="parent.move_type == 'entry'" />
                             <field name="price_unit" string="Price"
                                 column_invisible="parent.move_type == 'entry'" />
+                            <field name="tax_ids" widget="many2many_tags"
+                                column_invisible="parent.move_type == 'entry'" />
                             <field name="discount" string="Disc.%"
                                 width="50px"
                                 column_invisible="parent.move_type == 'entry'" />


### PR DESCRIPTION
## Summary
- link bank statement line to each operation line
- load taxes and price from product on move template lines
- propagate tax data through wizards and views

## Testing
- `python -m py_compile account_move_operation/models/account_move_operation.py account_move_template/models/account_move_template_line.py account_move_template/wizard/account_move_template_line_run.py account_move_template/wizard/account_move_template_run.py`

------
https://chatgpt.com/codex/tasks/task_b_6853132cee54832c95245c791abbdbae

## Resumen por Sourcery

Implementar la propagación de impuestos y precios para las líneas de plantillas de movimientos y vincular las líneas de extractos bancarios a las operaciones

Nuevas funcionalidades:
- Se ha añadido el campo `tax_ids` a las líneas de plantillas de movimientos contables y a los asistentes, se muestra en las vistas y se incluye en la preparación de movimientos.
- Autocompletar el precio unitario, los impuestos y la UoM del producto seleccionado a través de `onchange` en las líneas de la plantilla y del asistente.
- Vincular las líneas de extractos bancarios a las operaciones de movimientos contables añadiendo `st_line_id`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement tax and price propagation for move template lines and link bank statement lines to operations

New Features:
- Add tax_ids field to account move template lines and wizards, display in views, and include in move preparation
- Auto-populate unit price, taxes and UoM from selected product via onchange on template and wizard lines
- Link bank statement lines to account move operations by adding st_line_id

</details>