### PR TITLE
Implement st_line_id propagation and product info loading

### DIFF
--- a/account_move_operation/models/account_move_operation.py
+++ b/account_move_operation/models/account_move_operation.py
@@ -188,6 +188,7 @@ class AccountMoveOperation(models.Model):
             "state": "waiting",
             "template_id": rule.template_id.id,
             "operation_id": self.id,
+            "st_line_id": self.st_line_id.id,
             "date_last_document": rule.date_last_document,
             "diff_partner": rule.diff_partner,
             "action_id": rule.id,

--- a/account_move_operation/tests/test_account_move_operation.py
+++ b/account_move_operation/tests/test_account_move_operation.py
@@ -293,6 +293,26 @@ class TestAccountMoveTemplate(TestBankRecWidgetCommon):
         )
         self.assertEqual(operation.state, "done")
 
+    def test_01b_lines_have_st_line_id(self):
+        operation = self.operation_obj.create(
+            {
+                "operation_type_id": self.operation_type.id,
+                "currency_id": self.company.currency_id.id,
+                "company_id": self.company.id,
+            }
+        )
+        st_line = self._create_st_line(
+            500.0,
+            partner_id=self.partner.id,
+            journal_id=self.journal_bank.id,
+            company_id=self.company.id,
+        )
+        with Form(operation) as form_op:
+            form_op.st_line_id = st_line
+        form_op.save()
+        operation.action_start()
+        self.assertTrue(all(l.st_line_id == st_line for l in operation.line_ids))
+
     def test_02_cancel_operation(self):
         operation = self.operation_obj.create(
             {

--- a/account_move_template/models/account_move_template_line.py
+++ b/account_move_template/models/account_move_template_line.py
@@ -76,6 +76,10 @@ class AccountMoveTemplateLine(models.Model):
         string="Unit Price",
         digits="Product Price",
     )
+    tax_ids = fields.Many2many(
+        comodel_name="account.tax",
+        string="Taxes",
+    )
     discount = fields.Float(
         string="Discount (%)",
         digits="Discount",
@@ -129,3 +133,13 @@ class AccountMoveTemplateLine(models.Model):
 
         self.account_code = self.account_id.code_store
         self.account_id = False
+
+    @api.onchange("product_id")
+    def _onchange_product_id_values(self):
+        for line in self:
+            if not line.product_id:
+                line.price_unit = 0.0
+                line.tax_ids = False
+                continue
+            line.price_unit = line.product_id.list_price
+            line.tax_ids = line.product_id.taxes_id

--- a/account_move_template/tests/test_account_move_template.py
+++ b/account_move_template/tests/test_account_move_template.py
@@ -203,3 +203,17 @@ class TestAccountMoveTemplate(TransactionCase):
         self.assertEqual(aml.tax_ids[0], self.tax)
         with self.assertRaises(IntegrityError), mute_logger("odoo.sql_db"):
             template_2.name = template.name
+
+    def test_onchange_product_sets_price_and_taxes(self):
+        line = self.env['account.move.template.line'].new({})
+        line.product_id = self.env.ref('product.product_product_8')
+        line._onchange_product_id_values()
+        self.assertEqual(line.price_unit, line.product_id.list_price)
+        self.assertEqual(line.tax_ids, line.product_id.taxes_id)
+
+    def test_wizard_line_onchange_product_sets_price_and_taxes(self):
+        wizard = self.env['account.move.template.line.run'].new({})
+        wizard.product_id = self.env.ref('product.product_product_8')
+        wizard._onchange_product_id_values()
+        self.assertEqual(wizard.price_unit, wizard.product_id.list_price)
+        self.assertEqual(wizard.tax_ids, wizard.product_id.taxes_id)

--- a/account_move_template/views/account_move_template_views.xml
+++ b/account_move_template/views/account_move_template_views.xml
@@ -105,6 +105,9 @@
                                         column_invisible="parent.move_type == 'entry'" />
                                     <field name="price_unit" string="Price"
                                         column_invisible="parent.move_type == 'entry'" />
+                                    <field name="tax_ids" widget="many2many_tags"
+                                        domain="[('company_id', '=', parent.company_id)]"
+                                        column_invisible="parent.move_type == 'entry'"/>
                                     <field name="discount" width="50px" string="Disc.%"
                                         optional="hide"
                                         column_invisible="parent.move_type == 'entry'" />

--- a/account_move_template/wizard/account_move_template_line_run.py
+++ b/account_move_template/wizard/account_move_template_line_run.py
@@ -52,6 +52,10 @@ class AccountMoveTemplateLineRun(models.TransientModel):
         string="Unit Price",
         digits="Product Price",
     )
+    tax_ids = fields.Many2many(
+        comodel_name="account.tax",
+        string="Taxes",
+    )
     discount = fields.Float(
         string="Discount (%)",
         digits="Discount",
@@ -62,3 +66,15 @@ class AccountMoveTemplateLineRun(models.TransientModel):
     )
     python_code = fields.Text(string="Formula", readonly=True)
     note = fields.Char()
+
+    @api.onchange("product_id")
+    def _onchange_product_id_values(self):
+        for line in self:
+            if not line.product_id:
+                line.price_unit = 0.0
+                line.tax_ids = False
+                line.product_uom_id = False
+                continue
+            line.price_unit = line.product_id.list_price
+            line.tax_ids = line.product_id.taxes_id
+            line.product_uom_id = line.product_id.uom_id

--- a/account_move_template/wizard/account_move_template_run.py
+++ b/account_move_template/wizard/account_move_template_run.py
@@ -164,6 +164,9 @@ class AccountMoveTemplateRun(models.TransientModel):
             vals["product_id"] = line.product_id.id
             vals["quantity"] = self.quantity or line.quantity
             vals["price_unit"] = self.price_unit or line.price_unit or 0.0
+            vals["tax_ids"] = (
+                [Command.set(line.tax_ids.ids)] if line.tax_ids else False
+            )
             vals["discount"] = self.discount or line.discount
 
         return vals
@@ -220,6 +223,7 @@ class AccountMoveTemplateRun(models.TransientModel):
             "product_uom_id": tmpl_line.product_uom_id.id or False,
             "quantity": quantity,
             "price_unit": price_unit,
+            "tax_ids": [Command.set(tmpl_line.tax_ids.ids)] if tmpl_line.tax_ids else False,
             "discount": tmpl_line.discount or False,
             "balance": tmpl_line.balance or False,
             "python_code": (

--- a/account_move_template/wizard/account_move_template_run_views.xml
+++ b/account_move_template/wizard/account_move_template_run_views.xml
@@ -42,6 +42,9 @@
                                 column_invisible="parent.move_type == 'entry'" />
                             <field name="price_unit" string="Price"
                                 column_invisible="parent.move_type == 'entry'" />
+                            <field name="tax_ids" widget="many2many_tags"
+                                domain="[('company_id', '=', parent.company_id)]"
+                                column_invisible="parent.move_type == 'entry'" />
                             <field name="discount" string="Disc.%"
                                 width="50px"
                                 column_invisible="parent.move_type == 'entry'" />


### PR DESCRIPTION
## Summary
- add st_line_id to account move operation lines
- keep taxes and price from product in account move template lines
- propagate taxes to wizard lines and show them in list views
- set taxes when choosing a product in wizard lines
- test st_line_id propagation and onchange behaviors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_b_685322f9df60832cbbec07dd42b73dbe

## Resumen por Sourcery

Implementar la propagación de los IDs de las líneas de transferencia de stock a las líneas de operación de movimientos de cuenta y mejorar las plantillas de movimientos de cuenta con la carga automática del precio del producto, los impuestos y la UOM tanto en las líneas de la plantilla como en los asistentes.

Nuevas Funcionalidades:
- Propagar la referencia de la línea de transferencia de stock (st_line_id) a cada línea de operación de movimiento de cuenta.
- Establecer automáticamente el precio unitario, los impuestos y la UoM del producto elegido en las líneas de la plantilla de movimiento y en el asistente.

Mejoras:
- Incluir tax_ids en las columnas de la vista y en la preparación de los valores de las líneas de movimiento tanto para las plantillas como para los asistentes.

Pruebas:
- Añadir pruebas para la propagación de st_line_id en las líneas de operación.
- Añadir pruebas para la lógica onchange para cargar el precio y los impuestos para las líneas de la plantilla y del asistente.

<details>
<summary>Original summary in English</summary>

## Resumen por Sourcery

Propagar el campo st_line_id a las líneas de operación de movimientos contables, mejorar las líneas de plantilla de movimientos contables y el asistente asociado para cargar automáticamente los precios de los productos, los impuestos y la UoM, actualizar las vistas para mostrar los impuestos y añadir pruebas para estos comportamientos.

Nuevas Funcionalidades:
- Propagar la referencia de la línea de transferencia de stock (st_line_id) a las líneas de operación de movimientos contables
- Cargar automáticamente el precio del producto, los impuestos y la UoM al seleccionar un producto en las líneas de plantilla de movimientos contables y en el asistente

Mejoras:
- Incluir tax_ids en la plantilla de movimiento contable y en las vistas del asistente y en los valores de la línea de movimiento preparada

Pruebas:
- Añadir pruebas para la propagación de st_line_id en las líneas de operación
- Añadir pruebas para el comportamiento onchange que carga el precio y los impuestos en las líneas de la plantilla y del asistente

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Propagate the st_line_id field to account move operation lines, enhance account move template lines and the associated wizard to automatically load product pricing, taxes, and UoM, update views to display taxes, and add tests for these behaviors

New Features:
- Propagate stock transfer line reference (st_line_id) to account move operation lines
- Automatically load product price, taxes, and UoM when selecting a product in account move template lines and wizard

Enhancements:
- Include tax_ids in account move template and wizard views and in prepared move line values

Tests:
- Add tests for st_line_id propagation on operation lines
- Add tests for onchange behavior loading price and taxes in template and wizard lines

</details>

</details>