### PR TITLE
 [REF] estate_property: merge menus and update date logic

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'Modulo del JEM',
+    'version': '1.0',
+    'category': 'Tools',
+    'summary': 'Module for managing real estate advertising' ,
+    'depends': [
+        'base'
+        ],
+
+'data': [
+    'views/estate_property_views.xml',
+    'security/ir.model.access.csv',
+],
+
+    'installable': True,
+    'application': True,
+    'auto_install': False,
+}
+
+
+

--- a/estate/i18n/es_MX.po
+++ b/estate/i18n/es_MX.po
@@ -1,0 +1,183 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* estate
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server saas~18.2+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-22 17:39+0000\n"
+"PO-Revision-Date: 2025-08-22 17:39+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__active
+msgid "Active"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__bedrooms
+msgid "Bedrooms"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__state__cancelled
+msgid "Cancelado"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__date_availability
+msgid "Date Availability"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__description
+msgid "Description"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__state
+msgid "Estado"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__garden_orientation__east
+msgid "Este"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__expected_price
+msgid "Expected Price"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__facades
+msgid "Facades"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__garage
+msgid "Garage"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__garden
+msgid "Garden"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__garden_area
+msgid "Garden Area"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__garden_orientation
+msgid "Garden Orientation"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__id
+msgid "ID"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__living_area
+msgid "Living Area"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__name
+msgid "Name"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__garden_orientation__north
+msgid "Norte"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__state__new
+msgid "Nuevo"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__garden_orientation__west
+msgid "Oeste"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__state__offer_accepted
+msgid "Oferta Aceptada"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__state__offer_received
+msgid "Oferta Recibida"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__postcode
+msgid "Postcode"
+msgstr ""
+
+#. module: estate
+#: model:ir.actions.act_window,name:estate.estate_property_action
+#: model:ir.ui.menu,name:estate.estate_first_level_menu
+#: model:ir.ui.menu,name:estate.estate_property_menu_action
+msgid "Properties"
+msgstr ""
+
+#. module: estate
+#: model:ir.ui.menu,name:estate.estate_menu_root
+msgid "Real Estate"
+msgstr ""
+
+#. module: estate
+#: model:ir.model,name:estate.model_estate_property
+msgid "Real Estate Property"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__selling_price
+msgid "Selling Price"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__garden_orientation__south
+msgid "Sur"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__state__sold
+msgid "Vendido"
+msgstr ""

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -1,0 +1,1 @@
+from . import estate_property

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,0 +1,40 @@
+from odoo import fields, models
+from datetime import datetime, timedelta
+
+class EstateProperty(models.Model):
+    _name = "estate.property"
+    _description = "Real Estate Property"
+
+    name = fields.Char(required=True)
+
+    description = fields.Text()
+    postcode = fields.Char()
+    date_availability = fields.Date(
+        default=lambda self: fields.Date.today() + timedelta(days=90),
+        copy=False
+    )
+    expected_price = fields.Float(required=True)
+    selling_price = fields.Float(
+        readonly=True,
+        copy=False
+    )
+    bedrooms = fields.Integer(default=2)
+    living_area = fields.Integer()
+    facades = fields.Integer()
+    garage = fields.Boolean()
+    garden = fields.Boolean()
+    garden_area = fields.Integer()
+    garden_orientation = fields.Selection([
+        ('north', 'North'),
+        ('south', 'South'),
+        ('east', 'East'),
+        ('west', 'West'),
+    ])
+    active = fields.Boolean(default=True)
+    state = fields.Selection([
+        ('new', 'New'),
+        ('offer_received', 'Offer Received'),
+        ('offer_accepted', 'Offer Accepted'),
+        ('sold', 'Sold'),
+        ('cancelled', 'Cancelled'),
+    ], string="State", default='new', required=True, copy=False)

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_estate_property,access_estate_property,model_estate_property,,1,1,1,1

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -1,0 +1,37 @@
+<odoo>
+
+    <menuitem id="estate_menu_root" name="Real Estate">
+        <menuitem id="estate_first_level_menu" name="Properties">
+            <menuitem id="estate_property_menu_action" action="estate_property_action"/>
+        </menuitem>
+    </menuitem>
+    
+    <record id="estate_property_action" model="ir.actions.act_window">
+        <field name="name">Properties</field>
+        <field name="res_model">estate.property</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <record id="estate_property_list_view" model="ir.ui.view">
+        <field name="name">Properties List View</field>
+        <field name="model">estate.property</field>
+        <field name="type">list</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name"/>
+                <field name="postcode"/>
+                <field name="date_availability"/>
+                <field name="expected_price"/>
+                <field name="bedrooms"/>
+                <field name="living_area"/>
+                <field name="facades"/>
+                <field name="garage"/>
+                <field name="garden"/>
+                <field name="garden_area"/>
+                <field name="garden_orientation"/>
+                <field name="active"/>
+                <field name="state"/>
+            </list>
+        </field>
+    </record>
+</odoo>

--- a/marin/models/product_template.py
+++ b/marin/models/product_template.py
@@ -36,6 +36,15 @@ class ProductTemplate(models.Model):
         help="Used as default value on the vendor refunds lines. "
         "Leave empty to use the account from the product category.",
     )
+
+    #inicio creación de atributos
+
+    property_account_jem = fields.Char(
+        string="Nombre:",
+        help="Este es un campo de prueba para el Jem",
+    )
+    #fin creación de atributos
+
     use_dose = fields.Boolean(
         compute="_compute_use_expiration_date",
         store=True,

--- a/marin/views/product_template_views.xml
+++ b/marin/views/product_template_views.xml
@@ -140,6 +140,47 @@
                     <field name="x_dose" invisible="not use_dose" />
                 </div>
             </xpath>
+            <!-- inicio creación de nueva sección en ventas para mis pruebas-->
+
+            <xpath expr="//page[@name='sales']" position="inside">
+                <group>
+                    <div style="background:#fff;border-radius:12px;padding:24px;box-shadow:0 4px 16px #e0e0e0;">
+                        <h3 style="margin:0 0 16px 0;color:#222;font-weight:600;letter-spacing:1px;">Panel de JEM -VENTAS</h3>
+                        <div style="display:flex;gap:32px;align-items:center;justify-content:space-between;">
+                            <div style="background:#fff;border-radius:8px;padding:16px;min-width:180px;box-shadow:0 2px 8px #eee;">
+                                <span style="font-size:14px;color:#888;font-weight:500;">Precio de venta</span><br/>
+                                <span style="font-size:22px;color:#222;font-weight:600;">
+                                    <field name="list_price" class="oe_inline"/>
+                                </span>
+                            </div>
+                            <div style="background:#fff;border-radius:8px;padding:16px;min-width:180px;box-shadow:0 2px 8px #eee;">
+                                <span style="font-size:14px;color:#888;font-weight:500;">¿Se puede vender?</span><br/>
+                                <span style="font-size:22px;color:#222;font-weight:600;">
+                                    <field name="sale_ok" class="oe_inline"/>
+                                </span>
+                            </div>
+                            <div style="background:#fff;border-radius:8px;padding:16px;min-width:180px;box-shadow:0 2px 8px #eee;">
+                                <span style="font-size:14px;color:#888;font-weight:500;">Disponible en POS</span><br/>
+                                <span style="font-size:22px;color:#222;font-weight:600;">
+                                    <field name="available_in_pos" class="oe_inline"/>
+                                </span>
+                            </div>
+                        </div>
+                        <div style="margin-top:24px;display:flex;gap:32px;align-items:center;">
+                            <div style="background:#fff;border-radius:8px;padding:16px;min-width:220px;box-shadow:0 2px 8px #eee;">
+                                <span style="font-size:14px;color:#888;">Vendedores</span><br/>
+                                <field name="seller_ids" widget="many2many_tags" class="oe_inline"/>
+                            </div>
+                            <div style="background:#fff;border-radius:8px;padding:16px;min-width:220px;box-shadow:0 2px 8px #eee;">
+                                <span style="font-size:14px;color:#888;">Etiquetas de producto</span><br/>
+                                <field name="product_tag_ids" widget="many2many_tags" class="oe_inline"/>
+                            </div>
+                        </div>
+                    </div>
+                </group>
+            </xpath>
+            <!-- fin creación de nueva sección en ventas para mis pruebas-->
+
             <xpath expr="//field[@name='seller_ids']" position="attributes">
                 <!-- removed standard_price from context since it's in marin.group_product_cost_readonly causing 'Access Rights Inconsistency' (Task #5664) -->
                 <attribute name="context">{'default_product_tmpl_id': id, 'product_template_invisible_variant': True, 'list_view_ref':'purchase.product_supplierinfo_tree_view2'}</attribute>


### PR DESCRIPTION
- Eliminated estate_menus.xml and merged its content into
  estate_property_views.xml to simplify view management.

- Replaced datetime.today() with fields.Date.today() to
  automatically respect user's timezone.

- Removed 'models': ['estate.property'] from manifest as
  it was unnecessary.